### PR TITLE
Fix GA release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 5
+          persist-credentials: false
 
       - name: Setup Java 11 and Apache Maven
         uses: actions/setup-java@v1


### PR DESCRIPTION
The current GA release workflow fails to commit back next development version as the default fetch-depth is 1.