### PR TITLE
fixes #128 - throw away redundant shenanigans with classpath & module…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-gradle-plugin'
-    id 'com.github.hierynomus.license' version '0.15.0'
+    id 'com.github.hierynomus.license' version '0.16.1'
     id 'com.gradle.plugin-publish' version '1.0.0-rc-2'
     id 'com.github.ben-manes.versions' version '0.27.0'
     id 'maven-publish'


### PR DESCRIPTION
An attempt to fix #128 and #157.
--module-path has already configured by org.openjfx:javafx-plugin which is used side by side with this plugin.
There is no need to spoil this configuration with this redundant work. 

As reported in issues - nativeRunAgent doesn't work at all and this modification fixes it. 
Tested with Gradle 7.4.2 

