### PR TITLE
Fix Gradle 10 deprecation warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ plugins {
     id 'com.github.hierynomus.license' version '0.16.1'
 }
 
-group 'com.gluonhq'
-version '1.0.30-SNAPSHOT'
+group = 'com.gluonhq'
+version = '1.0.0-HC'
 
 java {
     toolchain.languageVersion = JavaLanguageVersion.of(17)
@@ -15,7 +15,7 @@ repositories {
     mavenCentral()
     gradlePluginPortal()
     maven {
-        url "https://central.sonatype.com/repository/maven-snapshots/"
+        url = "https://central.sonatype.com/repository/maven-snapshots/"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.gluonhq'
-version = '1.0.0-HC'
+version = '1.0.30-SNAPSHOT'
 
 java {
     toolchain.languageVersion = JavaLanguageVersion.of(17)

--- a/src/main/java/com/gluonhq/gradle/GluonFXPlugin.java
+++ b/src/main/java/com/gluonhq/gradle/GluonFXPlugin.java
@@ -81,8 +81,9 @@ public class GluonFXPlugin implements Plugin<Project> {
     }
     
     private void createTask(String name, Class<? extends Task> taskClass, String description) {
-        Task t = project.getTasks().create(name, taskClass, project);
-        t.setGroup("GluonFX");
-        t.setDescription(description);
+        project.getTasks().register(name, taskClass, project).configure(t -> {
+            t.setGroup("GluonFX");
+            t.setDescription(description);
+        });
     }
 }

--- a/src/main/java/com/gluonhq/gradle/attach/AttachConfiguration.java
+++ b/src/main/java/com/gluonhq/gradle/attach/AttachConfiguration.java
@@ -43,6 +43,7 @@ import org.gradle.api.artifacts.Configuration;
 
 import com.gluonhq.gradle.ClientExtension;
 import com.gluonhq.substrate.Constants;
+import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.ModuleDependency;
 
 public class AttachConfiguration {
@@ -124,14 +125,12 @@ public class AttachConfiguration {
 
         project.getLogger().info("Adding Attach dependencies for target: " + target);
         if (services != null && !services.isEmpty()) {
-            services.stream()
-                .map(asd -> generateDependencyNotation(asd, target))
-                .forEach(depNotion -> {
-                    ModuleDependency dep = (ModuleDependency) project.getDependencies().add(configName, depNotion);
-                    if (dep != null) {
-                        dep.exclude(Map.of("group", "org.openjfx", "module", "*"));
-                    }
-                });
+            services.forEach(asd -> {
+                ModuleDependency dep = generateDependency(asd, target, configName);
+                if (dep != null) {
+                    dep.exclude(Map.of("group", "org.openjfx", "module", "*"));
+                }
+            });
 
             // Also add util artifact if any other artifact added
             String utilClassifier = null;
@@ -140,8 +139,7 @@ public class AttachConfiguration {
                 utilClassifier = Constants.PROFILE_IOS_SIM.equals(target) ?
                         Constants.PROFILE_IOS : target;
             }
-            String utilDependencyNotation = toDependencyNotation(DEPENDENCY_GROUP, UTIL_ARTIFACT, getVersion(), utilClassifier);
-            ModuleDependency dep = (ModuleDependency) project.getDependencies().add(configName, utilDependencyNotation);
+            ModuleDependency dep = createDependency(UTIL_ARTIFACT, utilClassifier, configName);
             if (dep != null) {
                 dep.exclude(Map.of("group", "org.openjfx", "module", "*"));
             }
@@ -150,22 +148,34 @@ public class AttachConfiguration {
         lastAppliedConfiguration = configuration;
     }
 
-    private String generateDependencyNotation(AttachServiceDefinition asd, String target) {
-        String dependencyNotation = toDependencyNotation(DEPENDENCY_GROUP, asd.getName(), getVersion(), asd.getSupportedPlatform(target));
+    private ModuleDependency generateDependency(AttachServiceDefinition asd, String target, String configName) {
+        ModuleDependency dep = createDependency(asd.getName(), asd.getSupportedPlatform(target), configName);
 
-        project.getLogger().info("Adding dependency for {} in configuration {}: {}", asd.getService().getServiceName(), getConfiguration(), dependencyNotation);
-        return dependencyNotation;
+        project.getLogger().info("Adding dependency for {} in configuration {}: {}:{}:{}:{}", asd.getService().getServiceName(), getConfiguration(),
+                DEPENDENCY_GROUP, asd.getName(), getVersion(), asd.getSupportedPlatform(target));
+
+        return dep;
     }
 
     /**
-     * Builds Gradle's single-string dependency notation ("group:name:version[:classifier]").
-     * Map-based ("multi-string") notation is deprecated since Gradle 9 and will fail in Gradle 10.
+     * Creates and adds a dependency on "group:name:version" (Gradle's non-deprecated single-string
+     * notation) and, when a classifier is given, attaches it via the equally non-deprecated
+     * {@link ModuleDependency#artifact(Action)} API rather than embedding it in the coordinate
+     * string — this mirrors exactly what the old Map-based ("classifier" key) notation did
+     * internally, since embedding the classifier in the coordinate string altered dependency
+     * resolution in a way that broke native-image compilation for consumers.
      */
-    private static String toDependencyNotation(String group, String name, String version, String classifier) {
-        String notation = group + ":" + name + ":" + version;
+    private ModuleDependency createDependency(String name, String classifier, String configName) {
+        ExternalModuleDependency dep = (ExternalModuleDependency) project.getDependencies()
+                .create(DEPENDENCY_GROUP + ":" + name + ":" + getVersion());
         if (classifier != null) {
-            notation += ":" + classifier;
+            dep.artifact(artifact -> {
+                artifact.setName(name);
+                artifact.setType("jar");
+                artifact.setExtension("jar");
+                artifact.setClassifier(classifier);
+            });
         }
-        return notation;
+        return (ModuleDependency) project.getDependencies().add(configName, dep);
     }
 }

--- a/src/main/java/com/gluonhq/gradle/attach/AttachConfiguration.java
+++ b/src/main/java/com/gluonhq/gradle/attach/AttachConfiguration.java
@@ -32,7 +32,6 @@
 package com.gluonhq.gradle.attach;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -61,7 +60,7 @@ public class AttachConfiguration {
     @Inject
     public AttachConfiguration(Project project) {
         this.project = project;
-        this.services = project.container(AttachServiceDefinition.class);
+        this.services = project.getObjects().domainObjectContainer(AttachServiceDefinition.class);
     }
 
     public void version(String version) {
@@ -135,17 +134,14 @@ public class AttachConfiguration {
                 });
 
             // Also add util artifact if any other artifact added
-            Map<String, String> utilDependencyNotationMap = new HashMap<>();
-            utilDependencyNotationMap.put("group", DEPENDENCY_GROUP);
-            utilDependencyNotationMap.put("name", UTIL_ARTIFACT);
-            utilDependencyNotationMap.put("version", getVersion());
+            String utilClassifier = null;
             if (Constants.PROFILE_ANDROID.equals(target) || Constants.PROFILE_IOS.equals(target)
                     || Constants.PROFILE_IOS_SIM.equals(target)) {
-                String utilTarget = Constants.PROFILE_IOS_SIM.equals(target) ?
+                utilClassifier = Constants.PROFILE_IOS_SIM.equals(target) ?
                         Constants.PROFILE_IOS : target;
-                utilDependencyNotationMap.put("classifier", utilTarget);
             }
-            ModuleDependency dep = (ModuleDependency) project.getDependencies().add(configName, utilDependencyNotationMap);
+            String utilDependencyNotation = toDependencyNotation(DEPENDENCY_GROUP, UTIL_ARTIFACT, getVersion(), utilClassifier);
+            ModuleDependency dep = (ModuleDependency) project.getDependencies().add(configName, utilDependencyNotation);
             if (dep != null) {
                 dep.exclude(Map.of("group", "org.openjfx", "module", "*"));
             }
@@ -154,14 +150,22 @@ public class AttachConfiguration {
         lastAppliedConfiguration = configuration;
     }
 
-    private Map<String, String> generateDependencyNotation(AttachServiceDefinition asd, String target) {
-        Map<String, String> dependencyNotationMap = new HashMap<>();
-        dependencyNotationMap.put("group", DEPENDENCY_GROUP);
-        dependencyNotationMap.put("name", asd.getName());
-        dependencyNotationMap.put("version", getVersion());
-        dependencyNotationMap.put("classifier", asd.getSupportedPlatform(target));
+    private String generateDependencyNotation(AttachServiceDefinition asd, String target) {
+        String dependencyNotation = toDependencyNotation(DEPENDENCY_GROUP, asd.getName(), getVersion(), asd.getSupportedPlatform(target));
 
-        project.getLogger().info("Adding dependency for {} in configuration {}: {}", asd.getService().getServiceName(), getConfiguration(), dependencyNotationMap);
-        return dependencyNotationMap;
+        project.getLogger().info("Adding dependency for {} in configuration {}: {}", asd.getService().getServiceName(), getConfiguration(), dependencyNotation);
+        return dependencyNotation;
+    }
+
+    /**
+     * Builds Gradle's single-string dependency notation ("group:name:version[:classifier]").
+     * Map-based ("multi-string") notation is deprecated since Gradle 9 and will fail in Gradle 10.
+     */
+    private static String toDependencyNotation(String group, String name, String version, String classifier) {
+        String notation = group + ":" + name + ":" + version;
+        if (classifier != null) {
+            notation += ":" + classifier;
+        }
+        return notation;
     }
 }

--- a/src/main/java/com/gluonhq/gradle/tasks/NativeBuildTask.java
+++ b/src/main/java/com/gluonhq/gradle/tasks/NativeBuildTask.java
@@ -46,6 +46,6 @@ public class NativeBuildTask extends DefaultTask {
 
     @TaskAction
     public void action() {
-        getProject().getLogger().info("ClientNativeBuild action");
+        getLogger().info("ClientNativeBuild action");
     }
 }

--- a/src/main/java/com/gluonhq/gradle/tasks/NativeCompileTask.java
+++ b/src/main/java/com/gluonhq/gradle/tasks/NativeCompileTask.java
@@ -45,7 +45,7 @@ public class NativeCompileTask extends NativeBaseTask {
 
     @TaskAction
     public void action() {
-        getProject().getLogger().debug("ClientNativeCompile action");
+        getLogger().debug("ClientNativeCompile action");
         new ConfigBuild(project).build();
     }
 }

--- a/src/main/java/com/gluonhq/gradle/tasks/NativeInstallTask.java
+++ b/src/main/java/com/gluonhq/gradle/tasks/NativeInstallTask.java
@@ -47,7 +47,7 @@ public class NativeInstallTask extends NativeBaseTask {
 
     @TaskAction
     public void action() {
-        getProject().getLogger().info("ClientNativeInstall action");
+        getLogger().info("ClientNativeInstall action");
 
         boolean result;
         try {

--- a/src/main/java/com/gluonhq/gradle/tasks/NativeLinkTask.java
+++ b/src/main/java/com/gluonhq/gradle/tasks/NativeLinkTask.java
@@ -47,7 +47,7 @@ public class NativeLinkTask extends NativeBaseTask {
 
     @TaskAction
     public void action() {
-        getProject().getLogger().info("ClientNativeLink action");
+        getLogger().info("ClientNativeLink action");
 
         boolean result;
         try {

--- a/src/main/java/com/gluonhq/gradle/tasks/NativePackageTask.java
+++ b/src/main/java/com/gluonhq/gradle/tasks/NativePackageTask.java
@@ -47,7 +47,7 @@ public class NativePackageTask extends NativeBaseTask {
 
     @TaskAction
     public void action() {
-        getProject().getLogger().info("ClientNativePackage action");
+        getLogger().info("ClientNativePackage action");
 
         boolean result;
         try {

--- a/src/main/java/com/gluonhq/gradle/tasks/NativeRunAgentTask.java
+++ b/src/main/java/com/gluonhq/gradle/tasks/NativeRunAgentTask.java
@@ -86,7 +86,7 @@ public class NativeRunAgentTask extends NativeBaseTask {
 
     @TaskAction
     public void action() {
-        getProject().getLogger().info("ClientNativeRunAgent action");
+        getLogger().info("ClientNativeRunAgent action");
 
         Path graalVMHome = getGraalHome();
 

--- a/src/main/java/com/gluonhq/gradle/tasks/NativeRunTask.java
+++ b/src/main/java/com/gluonhq/gradle/tasks/NativeRunTask.java
@@ -46,7 +46,7 @@ public class NativeRunTask extends NativeBaseTask {
 
     @TaskAction
     public void action() {
-        getProject().getLogger().info("ClientNativeRun action");
+        getLogger().info("ClientNativeRun action");
 
         try {
             SubstrateDispatcher dispatcher = new ConfigBuild(project).createSubstrateDispatcher();


### PR DESCRIPTION
## Fix Gradle 10 deprecation warnings

Gradle 10 turns several currently-deprecated APIs into hard errors. This PR removes all such usages from the plugin so that both the plugin's own build and consuming projects can build cleanly on Gradle 10.

### Changes

- **`Task.getProject()` at execution time** — every native task (`NativeBuildTask`, `NativeCompileTask`, `NativeInstallTask`, `NativeLinkTask`, `NativePackageTask`, `NativeRunTask`, `NativeRunAgentTask`) called `getProject().getLogger()` inside its `@TaskAction` method. This is the most impactful fix, since it fires for every consumer of the plugin ("Invocation of Task.project at execution time has been deprecated. This will fail with an error in Gradle 10."). Replaced with `getLogger()`, which Task provides directly and is not subject to this restriction.
- **`Project.container(Class)`** in `AttachConfiguration` — replaced with `ObjectFactory.domainObjectContainer(Class)`.
- **`TaskContainer.create(...)`** (eager) in `GluonFXPlugin` — replaced with `TaskContainer.register(...)` for lazy task creation, avoiding the deprecated eager-creation API.
- **Groovy space-assignment syntax** in `build.gradle` (`group '...'`, `url "..."`) — replaced with `=` assignment.
- **Multi-string ("Map") dependency notation** in `AttachConfiguration` for the Attach service dependencies — replaced with single-string GAV coordinates, with the classifier attached via the dependency's `artifact { }` block rather than embedded in the coordinate string. (Embedding the classifier directly in the coordinate string, e.g. `"group:name:version:classifier"`, was tried first but caused a classpath conflict that broke `nativeCompile` for some consumers — using `artifact { classifier = ... }` instead avoids that while still using only non-deprecated APIs.)

### Testing

- `./gradlew build` (plugin's own build) runs warning-free with `--warning-mode all`.
- Verified with a consuming project (via `includeBuild`) that applying the plugin, running native tasks, and configuring `attachConfig { services ... }` no longer produce any deprecation output.
- Verified end-to-end against a real consuming project: `nativeCompile` and `nativePackage` (iOS) both complete successfully with the updated dependency notation.

### Additional Info

Some changes in this PR were supported by AI but all AI-generated changes were reviewed and approved by the author of the PR.
No functional/behavioral changes are intended — this is a compatibility-only cleanup.
